### PR TITLE
node-forge vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "resolve-url-loader": "^3.1.0",
         "sass": "^1.26.10",
         "sass-loader": "^8.0.0",
-        "vue-template-compiler": "^2.6.11"
+        "vue-template-compiler": "^2.6.11",
+        "node-forge": ">=0.10.0"
     }
 }


### PR DESCRIPTION
The package node-forge before 0.10.0 is vulnerable to Prototype Pollution via the util.setPath function. Note: Version 0.10.0 is a breaking change removing the vulnerable functions.